### PR TITLE
接入 Sentry 并添加 /crash 接口抛出除零异常

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,17 @@
 from flask import Flask, jsonify, request
 import os
 import time
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+
+sentry_dsn = os.environ.get("SENTRY_DSN")
+if sentry_dsn:
+    sentry_sdk.init(
+        dsn=sentry_dsn,
+        integrations=[FlaskIntegration()],
+        traces_sample_rate=1.0,
+        profiles_sample_rate=1.0,
+    )
 
 app = Flask(__name__)
 
@@ -37,6 +48,12 @@ def version():
         "env": "local-factory",
         "up_since": START_TIME
     })
+
+@app.route('/crash')
+def crash():
+    """Trigger a division by zero to test Sentry exception tracking."""
+    1 / 0
+    return "This should not be reached"
 
 @app.route("/v1/cal")
 def cal_v1():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
 pytest
+sentry-sdk[flask]


### PR DESCRIPTION
为了验证自愈闭环，加入了 Sentry SDK 和 /crash 接口。