### PR TITLE
feat: add /sentry_test endpoint for forced crash testing

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,6 +60,20 @@ def crash():
         return jsonify({"error": "division by zero caught and reported"}), 500
     return "This should not be reached"
 
+@app.route('/sentry_test')
+def sentry_test():
+    """Explicitly capture an exception and then force a crash."""
+    try:
+        raise RuntimeError("Manual Sentry Test Crash")
+    except Exception as e:
+        import sentry_sdk
+        sentry_sdk.capture_exception(e)
+        sentry_sdk.flush(timeout=2.0)
+        # Force exit to simulate a hard crash
+        import os
+        os._exit(1)
+    return "This should not be reached"
+
 @app.route("/v1/cal")
 def cal_v1():
     """Legacy contract: result = a + b + 1. Current default is GET /cal (v2, a + b + 2)."""


### PR DESCRIPTION
This PR adds a test endpoint that triggers a RuntimeError, reports it to Sentry, and then forces a process exit. Fulfills issue #27