### PR TITLE
Add /sentry_test_1: new Sentry issue per request (OWE-30)

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,6 +60,20 @@ def crash():
         return jsonify({"error": "division by zero caught and reported"}), 500
     return "This should not be reached"
 
+@app.route('/sentry_test')
+def sentry_test():
+    """Explicitly capture an exception and then force a crash."""
+    try:
+        raise RuntimeError("Manual Sentry Test Crash")
+    except Exception as e:
+        import sentry_sdk
+        sentry_sdk.capture_exception(e)
+        sentry_sdk.flush(timeout=2.0)
+        # Force exit to simulate a hard crash
+        import os
+        os._exit(1)
+    return "This should not be reached"
+
 @app.route("/v1/cal")
 def cal_v1():
     """Legacy contract: result = a + b + 1. Current default is GET /cal (v2, a + b + 2)."""

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify, request
 import os
 import time
+import uuid
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 
@@ -73,6 +74,43 @@ def sentry_test():
         import os
         os._exit(1)
     return "This should not be reached"
+
+
+@app.route("/sentry_test_1")
+def sentry_test_1():
+    """
+    Send one Sentry event per request. A unique fingerprint is used so each
+    call groups as a new issue in Sentry (not merged with prior invocations).
+    """
+    if not sentry_dsn:
+        return (
+            jsonify(
+                {
+                    "ok": True,
+                    "sent": False,
+                    "reason": "SENTRY_DSN is not set; Sentry client was not initialized",
+                }
+            ),
+            200,
+        )
+
+    event_id = str(uuid.uuid4())
+    with sentry_sdk.new_scope() as scope:
+        scope.fingerprint = [event_id]
+        scope.set_tag("endpoint", "sentry_test_1")
+        sentry_sdk.capture_message(
+            f"sentry_test_1 manual issue ({event_id})",
+            level="error",
+        )
+    sentry_sdk.flush(timeout=2.0)
+    return jsonify(
+        {
+            "ok": True,
+            "sent": True,
+            "event_id": event_id,
+        }
+    )
+
 
 @app.route("/v1/cal")
 def cal_v1():

--- a/test_app.py
+++ b/test_app.py
@@ -1,7 +1,10 @@
 """HTTP tests for app routes."""
 
+from unittest.mock import patch
+
 import pytest
 
+import app as app_module
 from app import app
 
 
@@ -45,3 +48,25 @@ def test_health(client):
     r = client.get("/health")
     assert r.status_code == 200
     assert r.get_json()["status"] == "ok"
+
+
+def test_sentry_test_1_skips_sentry_without_dsn(client, monkeypatch):
+    monkeypatch.setattr(app_module, "sentry_dsn", None)
+    r = client.get("/sentry_test_1")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["ok"] is True
+    assert data["sent"] is False
+    assert "reason" in data
+
+
+def test_sentry_test_1_sends_with_dsn(client, monkeypatch):
+    monkeypatch.setattr(app_module, "sentry_dsn", "https://example@o1.ingest.sentry.io/1")
+    with patch("sentry_sdk.capture_message") as cap_m, patch("sentry_sdk.flush"):
+        r = client.get("/sentry_test_1")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["ok"] is True
+    assert data["sent"] is True
+    assert "event_id" in data
+    assert cap_m.call_count == 1


### PR DESCRIPTION
Implements GET /sentry_test_1. Each call sends a Sentry error-level message with a unique UUID fingerprint so Sentry groups each request as a separate issue instead of rolling up into one. When SENTRY_DSN is unset, the handler returns a clear JSON body without calling Sentry. Pytest coverage added for both paths.